### PR TITLE
chore: add set up for local pg with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+init:
+	poetry run docker run --name jaffel_shop_db -p 5432:5432 -e POSTGRES_USER=jaffeler -e POSTGRES_PASSWORD=1234supersafe -e POSTGRES_DB=jaffel_shop -d postgres
+
+configure:
+	docker run --rm --link jaffel_shop_db:postgres --volume `pwd`/scripts:/scripts -e PGPASSWORD=1234supersafe postgres psql --host postgres --username jaffeler -d jaffel_shop --file /scripts/setup_postgres.sql

--- a/scripts/setup_postgres.sql
+++ b/scripts/setup_postgres.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE raw;
+CREATE DATABASE transformed;


### PR DESCRIPTION
Add make commands to set up a local pg database. This assumes that Docker desktop is installed and running.